### PR TITLE
Feat: Add reset password feature with tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/validator": "6.3.*",
         "symfony/webpack-encore-bundle": "^2.2",
         "symfony/yaml": "6.3.*",
+        "symfonycasts/reset-password-bundle": "^1.23",
         "symfonycasts/verify-email-bundle": "*",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0"
@@ -89,6 +90,8 @@
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "6.3.*",
         "symfony/css-selector": "6.3.*",
-        "symfony/maker-bundle": "^1.51"
+        "symfony/maker-bundle": "^1.51",
+        "symfony/stopwatch": "6.3.*",
+        "symfony/web-profiler-bundle": "6.3.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06faf7979bb386b8bf306b0902897600",
+    "content-hash": "7794dcb695f8c99b81259d21666b1214",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -5902,6 +5902,53 @@
             "time": "2024-01-23T14:35:58+00:00"
         },
         {
+            "name": "symfonycasts/reset-password-bundle",
+            "version": "v1.23.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SymfonyCasts/reset-password-bundle.git",
+                "reference": "beff941f4d7f8ad7fbd32e482e13acbcefa0dde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SymfonyCasts/reset-password-bundle/zipball/beff941f4d7f8ad7fbd32e482e13acbcefa0dde4",
+                "reference": "beff941f4d7f8ad7fbd32e482e13acbcefa0dde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.10",
+                "symfony/config": "^5.4 | ^6.0 | ^7.0",
+                "symfony/dependency-injection": "^5.4 | ^6.0 | ^7.0",
+                "symfony/deprecation-contracts": "^2.2 | ^3.0",
+                "symfony/http-kernel": "^5.4 | ^6.0 | ^7.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.0",
+                "doctrine/doctrine-bundle": "^2.8",
+                "doctrine/orm": "^2.13",
+                "symfony/framework-bundle": "^5.4 | ^6.0 | ^7.0",
+                "symfony/phpunit-bridge": "^5.4 | ^6.0 | ^7.0",
+                "symfony/process": "^6.4 | ^7.0 | ^7.1",
+                "symfonycasts/internal-test-helpers": "dev-main"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "SymfonyCasts\\Bundle\\ResetPassword\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Symfony bundle that adds password reset functionality.",
+            "support": {
+                "issues": "https://github.com/SymfonyCasts/reset-password-bundle/issues",
+                "source": "https://github.com/SymfonyCasts/reset-password-bundle/tree/v1.23.2"
+            },
+            "time": "2025-06-27T20:32:48+00:00"
+        },
+        {
             "name": "symfonycasts/verify-email-bundle",
             "version": "v1.17.3",
             "source": {
@@ -8340,6 +8387,87 @@
                 }
             ],
             "time": "2024-01-23T14:35:58+00:00"
+        },
+        {
+            "name": "symfony/web-profiler-bundle",
+            "version": "v6.3.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
+                "reference": "920efdd0f53f088b44963cf89368038ee39719b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/920efdd0f53f088b44963cf89368038ee39719b9",
+                "reference": "920efdd0f53f088b44963cf89368038ee39719b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/framework-bundle": "^5.4|^6.0,<6.4",
+                "symfony/http-kernel": "^6.3",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "conflict": {
+                "symfony/form": "<5.4",
+                "symfony/mailer": "<5.4",
+                "symfony/messenger": "<5.4"
+            },
+            "require-dev": {
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\WebProfilerBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a development tool that gives detailed information about the execution of any request",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dev"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/web-profiler-bundle/tree/v6.3.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T16:21:43+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,4 +12,6 @@ return [
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle::class => ['all' => true],
+    SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/config/packages/reset_password.yaml
+++ b/config/packages/reset_password.yaml
@@ -1,0 +1,5 @@
+symfonycasts_reset_password:
+    # Replace symfonycasts.reset_password.fake_request_repository with the full
+    # namespace of the password reset request repository after it has been created.
+    # i.e. App\Repository\ResetPasswordRequestRepository
+    request_password_repository: App\Repository\ResetPasswordRequestRepository

--- a/config/packages/web_profiler.yaml
+++ b/config/packages/web_profiler.yaml
@@ -1,0 +1,11 @@
+when@dev:
+    web_profiler:
+        toolbar: true
+
+    framework:
+        profiler:
+            collect_serializer_data: true
+
+when@test:
+    framework:
+        profiler: { collect: false }

--- a/config/routes/web_profiler.yaml
+++ b/config/routes/web_profiler.yaml
@@ -1,0 +1,8 @@
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+        prefix: /_wdt
+
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+        prefix: /_profiler

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,6 +25,10 @@ services:
         arguments:
             $fromAddress: '%app.mailer_from_address%'
             $fromName: '%app.mailer_from_name%'
+    App\Controller\ResetPasswordController:
+        arguments:
+            $fromAddress: '%app.mailer_from_address%'
+            $fromName: '%app.mailer_from_name%'
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 

--- a/migrations/Version20250913194411.php
+++ b/migrations/Version20250913194411.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250913194411 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql(<<<'SQL'
+            CREATE TABLE reset_password_request (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, selector VARCHAR(20) NOT NULL, hashed_token VARCHAR(100) NOT NULL, requested_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', expires_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX IDX_7CE748AA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE reset_password_request ADD CONSTRAINT FK_7CE748AA76ED395 FOREIGN KEY (user_id) REFERENCES user (id)
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE user DROP reset_token, DROP reset_token_expires_at
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql(<<<'SQL'
+            ALTER TABLE reset_password_request DROP FOREIGN KEY FK_7CE748AA76ED395
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP TABLE reset_password_request
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE user ADD reset_token VARCHAR(255) DEFAULT NULL, ADD reset_token_expires_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)'
+        SQL);
+    }
+}

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -68,6 +68,7 @@ class RegistrationController extends AbstractController
                     ->subject('Please Confirm your Email')
                     ->htmlTemplate('mail/confirmation_email_student.html.twig')
             );
+
             return $this->redirectToRoute('app_check_email');
         }
 

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\ChangePasswordFormType;
+use App\Form\ResetPasswordRequestFormType;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
+use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+#[Route('/reset-password')]
+class ResetPasswordController extends AbstractController
+{
+    use ResetPasswordControllerTrait;
+
+    public function __construct(
+        private ResetPasswordHelperInterface $resetPasswordHelper,
+        private EntityManagerInterface $entityManager,
+        private string $fromAddress,
+        private string $fromName,
+        private LoggerInterface $logger
+    ) {}
+
+    /**
+     * Display & process form to request a password reset.
+     */
+    #[Route('', name: 'app_reset_password_request')]
+    public function request(Request $request, MailerInterface $mailer): Response
+    {
+        $form = $this->createForm(ResetPasswordRequestFormType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            return $this->processSendingPasswordResetEmail(
+                $form->get('email')->getData(),
+                $mailer
+            );
+        }
+
+        return $this->render('reset_password/request.html.twig', [
+            'requestForm' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * Confirmation page after a user has requested a password reset.
+     */
+    #[Route('/check-email', name: 'app_reset_password_check_email')]
+    public function checkEmail(): Response
+    {
+        // Generate a fake token if the user does not exist or someone hit this page directly.
+        // This prevents exposing whether or not a user was found with the given email address or not
+        if (null === ($resetToken = $this->getTokenObjectFromSession())) {
+            $resetToken = $this->resetPasswordHelper->generateFakeResetToken();
+        }
+
+        return $this->render('reset_password/check_email.html.twig', [
+            'resetToken' => $resetToken,
+        ]);
+    }
+
+    /**
+     * Validates and process the reset URL that the user clicked in their email.
+     */
+    #[Route('/reset/{token}', name: 'app_reset_password')]
+    public function reset(Request $request, UserPasswordHasherInterface $passwordHasher, string $token = null): Response
+    {
+        if ($token) {
+            // We store the token in session and remove it from the URL, to avoid the URL being
+            // loaded in a browser and potentially leaking the token to 3rd party JavaScript.
+            $this->storeTokenInSession($token);
+
+            return $this->redirectToRoute('app_reset_password');
+        }
+
+        $token = $this->getTokenFromSession();
+
+        if (null === $token) {
+            throw $this->createNotFoundException('No reset password token found in the URL or in the session.');
+        }
+
+        try {
+            $user = $this->resetPasswordHelper->validateTokenAndFetchUser($token);
+        } catch (ResetPasswordExceptionInterface $e) {
+            $this->addFlash('reset_password_error', sprintf(
+                '%s - %s',
+                ResetPasswordExceptionInterface::MESSAGE_PROBLEM_VALIDATE,
+                $e->getReason()
+            ));
+
+            return $this->redirectToRoute('app_reset_password_request');
+        }
+
+        // The token is valid; allow the user to change their password.
+        $form = $this->createForm(ChangePasswordFormType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // A password reset token should be used only once, remove it.
+            $this->resetPasswordHelper->removeResetRequest($token);
+
+            // Encode(hash) the plain password, and set it.
+            $encodedPassword = $passwordHasher->hashPassword(
+                $user,
+                $form->get('plainPassword')->getData()
+            );
+
+            $user->setPassword($encodedPassword);
+            $this->entityManager->flush();
+
+            // The session is cleaned up after the password has been changed.
+            $this->cleanSessionAfterReset();
+
+            return $this->redirectToRoute('app_login');
+        }
+
+        return $this->render('reset_password/reset.html.twig', [
+            'resetForm' => $form->createView(),
+        ]);
+    }
+
+    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer): RedirectResponse
+    {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy([
+            'email' => $emailFormData,
+        ]);
+
+        // Do not reveal whether a user account was found or not.
+        if (!$user) {
+            return $this->redirectToRoute('app_reset_password_check_email');
+        }
+
+        try {
+            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+        } catch (ResetPasswordExceptionInterface $e) {
+            return $this->redirectToRoute('app_reset_password_check_email');
+        }
+
+        $email = (new TemplatedEmail())
+            ->from(new Address($this->fromAddress, $this->fromName))
+            ->to($user->getEmail())
+            ->subject('Your password reset request')
+            ->htmlTemplate('mail/reset_password_email.html.twig')
+            ->context([
+                'resetToken' => $resetToken,
+            ])
+        ;
+
+        try {
+            $mailer->send($email);
+        }catch (\Throwable $e) {
+
+            // If there is an error sending the email, we can log it or handle it as needed.
+            // For now, we will just redirect to the check email page.
+            return $this->redirectToRoute('app_reset_password_check_email');
+        }
+
+        // Store the token object in session for retrieval in check-email route.
+        $this->setTokenObjectInSession($resetToken);
+
+        return $this->redirectToRoute('app_reset_password_check_email');
+    }
+}

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -160,7 +160,7 @@ class ResetPasswordController extends AbstractController
 
         try {
             $mailer->send($email);
-        }catch (\Throwable $e) {
+        } catch (\Throwable $e) {
 
             // If there is an error sending the email, we can log it or handle it as needed.
             // For now, we will just redirect to the check email page.

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -18,7 +18,7 @@ class SecurityController extends AbstractController
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
          if ($this->getUser()) {
-             return $this->redirectToRoute('app_site_index');
+             return $this->redirectToRoute('app_home');
          }
 
         // get the login error if there is one

--- a/src/Controller/SiteController.php
+++ b/src/Controller/SiteController.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 #[Route('/')]
 class SiteController extends AbstractController
 {
-    #[Route('/', name: 'app_site_index', methods: ['GET'])]
+    #[Route('/', name: 'app_home', methods: ['GET'])]
     public function index(): Response
     {
         return $this->render('index.html.twig');

--- a/src/Entity/ResetPasswordRequest.php
+++ b/src/Entity/ResetPasswordRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ResetPasswordRequestRepository;
+use Doctrine\ORM\Mapping as ORM;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
+
+#[ORM\Entity(repositoryClass: ResetPasswordRequestRepository::class)]
+class ResetPasswordRequest implements ResetPasswordRequestInterface
+{
+    use ResetPasswordRequestTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    public function __construct(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+    {
+        $this->user = $user;
+        $this->initialize($expiresAt, $selector, $hashedToken);
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): object
+    {
+        return $this->user;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -39,12 +39,6 @@ abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 45)]
     private ?string $lastName;
 
-    #[ORM\Column(type: 'string', nullable: true)]
-    private ?string $resetToken = null;
-
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
-    private ?\DateTimeImmutable $resetTokenExpiresAt = null;
-
     #[ORM\Column(type: 'datetime_immutable')]
     private ?\DateTimeImmutable $createdAt;
 
@@ -158,28 +152,6 @@ abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setIsVerified(bool $isVerified): static
     {
         $this->isVerified = $isVerified;
-        return $this;
-    }
-
-    public function getResetToken(): ?string
-    {
-        return $this->resetToken;
-    }
-
-    public function setResetToken(?string $resetToken): static
-    {
-        $this->resetToken = $resetToken;
-        return $this;
-    }
-
-    public function getResetTokenExpiresAt(): ?\DateTimeImmutable
-    {
-        return $this->resetTokenExpiresAt;
-    }
-
-    public function setResetTokenExpiresAt(?\DateTimeImmutable $resetTokenExpiresAt): static
-    {
-        $this->resetTokenExpiresAt = $resetTokenExpiresAt;
         return $this;
     }
 

--- a/src/Form/ChangePasswordFormType.php
+++ b/src/Form/ChangePasswordFormType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
+
+class ChangePasswordFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('plainPassword', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'first_options'  => ['label' => 'New Password'],
+                'second_options' => ['label' => 'Repeat Password'],
+                'invalid_message' => 'Passwords must match.',
+                'mapped' => false,
+                'attr' => ['autocomplete' => 'new-password'],
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Please enter a password.',
+                    ]),
+                    new Length([
+                        'min' => 6,
+                        'minMessage' => 'Your password should be at least {{ limit }} characters',
+                        'max' => 255
+                    ]),
+                    new Regex([
+                        'pattern' => '/^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[\W_]).{6,}$/',
+                        'message' => 'Your password must contain at least one uppercase letter, one lowercase letter, one number and one special character.',
+                    ])
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([]);
+    }
+}

--- a/src/Form/ResetPasswordRequestFormType.php
+++ b/src/Form/ResetPasswordRequestFormType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class ResetPasswordRequestFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class, [
+                'attr' => ['autocomplete' => 'email'],
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Please enter your email',
+                    ]),
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([]);
+    }
+}

--- a/src/Repository/ResetPasswordRequestRepository.php
+++ b/src/Repository/ResetPasswordRequestRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ResetPasswordRequest;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\Repository\ResetPasswordRequestRepositoryTrait;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
+
+/**
+ * @extends ServiceEntityRepository<ResetPasswordRequest>
+ *
+ * @method ResetPasswordRequest|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ResetPasswordRequest|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ResetPasswordRequest[]    findAll()
+ * @method ResetPasswordRequest[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ResetPasswordRequestRepository extends ServiceEntityRepository implements ResetPasswordRequestRepositoryInterface
+{
+    use ResetPasswordRequestRepositoryTrait;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ResetPasswordRequest::class);
+    }
+
+    public function createResetPasswordRequest(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken): ResetPasswordRequestInterface
+    {
+        return new ResetPasswordRequest($user, $expiresAt, $selector, $hashedToken);
+    }
+}

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -48,7 +48,7 @@ class LoginFormAuthenticator extends AbstractLoginFormAuthenticator
             return new RedirectResponse($targetPath);
         }
 
-        return new RedirectResponse($this->urlGenerator->generate('app_site_index'));
+        return new RedirectResponse($this->urlGenerator->generate('app_home'));
     }
 
     protected function getLoginUrl(Request $request): string

--- a/symfony.lock
+++ b/symfony.lock
@@ -196,6 +196,19 @@
             "config/packages/validator.yaml"
         ]
     },
+    "symfony/web-profiler-bundle": {
+        "version": "6.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.1",
+            "ref": "8b51135b84f4266e3b4c8a6dc23c9d1e32e543b7"
+        },
+        "files": [
+            "config/packages/web_profiler.yaml",
+            "config/routes/web_profiler.yaml"
+        ]
+    },
     "symfony/webpack-encore-bundle": {
         "version": "2.1",
         "recipe": {
@@ -210,6 +223,18 @@
             "config/packages/webpack_encore.yaml",
             "package.json",
             "webpack.config.js"
+        ]
+    },
+    "symfonycasts/reset-password-bundle": {
+        "version": "1.23",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "97c1627c0384534997ae1047b93be517ca16de43"
+        },
+        "files": [
+            "config/packages/reset_password.yaml"
         ]
     },
     "symfonycasts/verify-email-bundle": {

--- a/templates/mail/reset_password_email.html.twig
+++ b/templates/mail/reset_password_email.html.twig
@@ -1,0 +1,11 @@
+<h1>Hi!</h1>
+
+<p>We received a request to reset your SpeakUp account password.</p>
+<p>To reset your password, please visit the following link</p>
+
+<a href="{{ url('app_reset_password', {token: resetToken.token}) }}">{{ url('app_reset_password', {token: resetToken.token}) }}</a>
+
+<p>This link will expire in {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.</p>
+
+<p>Cheers!</p>
+

--- a/templates/reset_password/check_email.html.twig
+++ b/templates/reset_password/check_email.html.twig
@@ -1,0 +1,13 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Password Reset Email Sent{% endblock %}
+
+{% block body %}
+    <h1>Password Reset Email Sent</h1>
+
+    <p>
+        If an account matching your email exists, then an email was just sent that contains a link that you can use to reset your password.
+        This link will expire in {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.
+    </p>
+    <p>If you don't receive an email please check your spam folder or <a href="{{ path('app_reset_password_request') }}">try again</a>.</p>
+{% endblock %}

--- a/templates/reset_password/request.html.twig
+++ b/templates/reset_password/request.html.twig
@@ -1,0 +1,23 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Reset your password{% endblock %}
+
+{% block body %}
+    {% for flash_error in app.flashes('reset_password_error') %}
+        <div class="alert alert-danger" role="alert">{{ flash_error }}</div>
+    {% endfor %}
+
+    <h1>Reset your password</h1>
+
+    {{ form_start(requestForm) }}
+        {{ form_row(requestForm.email) }}
+        <div>
+            <small>
+                Enter your email address, and we will send you a
+                link to reset your password.
+            </small>
+        </div>
+
+        <button class="btn btn-primary">Send password reset email</button>
+    {{ form_end(requestForm) }}
+{% endblock %}

--- a/templates/reset_password/reset.html.twig
+++ b/templates/reset_password/reset.html.twig
@@ -1,0 +1,31 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Reset your password{% endblock %}
+
+{% block body %}
+    <h1>Reset your password</h1>
+
+    {{ form_errors(resetForm) }}
+    {{ form_start(resetForm) }}
+    <div class="form-group">
+        <div class="form-group">
+            {{ form_label(resetForm.plainPassword.first) }}
+            {{ form_widget(resetForm.plainPassword.first) }}
+            {% for error in resetForm.plainPassword.first.vars.errors %}
+                <div class="form-error-message">{{ error.message }}</div>
+            {% endfor %}
+        </div>
+        <div class="form-group">
+            {{ form_label(resetForm.plainPassword.second) }}
+            {{ form_widget(resetForm.plainPassword.second) }}
+            {% for error in resetForm.plainPassword.second.vars.errors %}
+                <div class="form-error-message">{{ error.message }}</div>
+            {% endfor %}
+        </div>
+        {% for error in resetForm.plainPassword.vars.errors %}
+            <div class="form-error-message">{{ error.message }}</div>
+        {% endfor %}
+    </div>
+        <button class="btn btn-primary">Reset password</button>
+    {{ form_end(resetForm) }}
+{% endblock %}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -35,5 +35,5 @@
         Sign in
     </button>
 </form>
-    <a href="{{ path ('app_reset_password_request')}}">Forgot your password?</a>
+    <a href="{{ path('app_reset_password_request')}}">Forgot your password?</a>
 {% endblock %}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -35,4 +35,5 @@
         Sign in
     </button>
 </form>
+    <a href="{{ path ('app_reset_password_request')}}">Forgot your password?</a>
 {% endblock %}

--- a/tests/ResetPasswordControllerTest.php
+++ b/tests/ResetPasswordControllerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 
-use App\Controller\ResetPasswordController;
 use App\Entity\ResetPasswordRequest;
 use App\Entity\Student;
 use App\Entity\User;
@@ -68,7 +67,7 @@ class ResetPasswordControllerTest extends WebTestCase
         $this->assertResponseRedirects('/reset-password/check-email');
         $this->assertEmailCount(1);
         $email = $this->getMailerMessage(0);
-        $crawler = self::$client->followRedirect();
+        self::$client->followRedirect();
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'Password Reset Email Sent');
 
@@ -102,7 +101,7 @@ class ResetPasswordControllerTest extends WebTestCase
         $resetUrl = $matches[1];
 
         // Simulate clicking the reset link
-        $crawler = self::$client->request('GET', $resetUrl);
+        self::$client->request('GET', $resetUrl);
         $this->assertResponseRedirects('/reset-password/reset');
         $crawler = self::$client->followRedirect();
         $this->assertResponseIsSuccessful();
@@ -146,7 +145,7 @@ class ResetPasswordControllerTest extends WebTestCase
         // Assert that we are redirected to the check email page and no email is sent
         $this->assertResponseRedirects('/reset-password/check-email');
         $this->assertEmailCount(0);
-        $crawler = self::$client->followRedirect();
+        self::$client->followRedirect();
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'Password Reset Email Sent');
 
@@ -163,7 +162,7 @@ class ResetPasswordControllerTest extends WebTestCase
      */
     public function testResetPasswordWithInvalidToken() : void
     {
-        $crawler = self::$client->request('GET', '/reset-password/reset/invalidtoken1234');
+        self::$client->request('GET', '/reset-password/reset/invalidtoken1234');
 
         // Check if there is redirect after saving token in session
         $this->assertResponseRedirects('/reset-password/reset');

--- a/tests/ResetPasswordControllerTest.php
+++ b/tests/ResetPasswordControllerTest.php
@@ -1,0 +1,364 @@
+<?php
+
+
+use App\Controller\ResetPasswordController;
+use App\Entity\ResetPasswordRequest;
+use App\Entity\Student;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+class ResetPasswordControllerTest extends WebTestCase
+{
+    private static $client;
+
+    /**
+     * @return void
+     * Sets up the test environment by creating a client and clearing the User table.
+     */
+    protected function setUp(): void
+    {
+        self::$client = static::createClient();
+        $container = self::$client->getContainer();
+
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $em->createQuery('DELETE FROM App\Entity\ResetPasswordRequest r WHERE r.user IS NOT NULL')->execute();
+
+        $em->createQuery('DELETE FROM App\Entity\User u WHERE u.email in (:email)')
+            ->setParameter('email',
+                [
+                    'reset_student@example.com',
+                ])
+            ->execute();
+
+
+        $user = new Student();
+        $user->setEmail('reset_student@example.com')
+            ->setName('Test')
+            ->setLastName('Student')
+            ->setPassword($hasher->hashPassword($user, 'Password123-'))
+            ->setIsVerified(true)
+            ->setCreatedAt(new DateTimeImmutable());
+        $em->persist($user);
+
+        $em->flush();
+    }
+
+
+    /**
+     * Tests the password reset request process for an existing user.
+     * @return void
+     */
+    public function testRequestResetPasswordForExistingUser() : void
+    {
+        $crawler = self::$client->request('GET', '/reset-password');
+        $form = $crawler->selectButton('Send password reset email')->form([
+            'reset_password_request_form[email]' => 'reset_student@example.com'
+        ]);
+        self::$client->submit($form);
+
+        // Assert that we are redirected to the check email page
+        $this->assertResponseRedirects('/reset-password/check-email');
+        $this->assertEmailCount(1);
+        $email = $this->getMailerMessage(0);
+        $crawler = self::$client->followRedirect();
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Password Reset Email Sent');
+
+        //Check if token has been set for the user
+        $container = self::$client->getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        /** @var Student $user */
+        $user = $em->getRepository(Student::class)->findOneBy(['email' => 'reset_student@example.com']);
+
+        /** @var ResetPasswordRequest $resetRequest */
+        $resetRequest = $em->getRepository(ResetPasswordRequest::class)->findOneBy(['user' => $user]);
+        $this->assertNotNull($resetRequest);
+
+        //Check reset password request details
+        $this->assertNotEmpty($resetRequest->getHashedToken(), 'Hashed token should not be empty');
+        $this->assertGreaterThan(new DateTimeImmutable(), $resetRequest->getExpiresAt(), 'Expiration date should be in the future');
+
+        // Check email details
+        $fromAddress = self::getContainer()->getParameter('app.mailer_from_address');
+        $fromName = self::getContainer()->getParameter('app.mailer_from_name');
+        $this->assertEmailHeaderSame($email, 'to', 'reset_student@example.com');
+        $this->assertEmailHeaderSame($email, 'from', sprintf('%s <%s>', $fromName, $fromAddress));
+        $this->assertEmailHeaderSame($email, 'subject', 'Your password reset request');
+        $this->assertEmailHtmlBodyContains($email, '/reset-password/reset/');
+
+        // Extract the reset URL from the email
+        preg_match('/href="([^"]*\/reset-password\/reset\/[^"]*)"/', $email->getHtmlBody(), $matches);
+        $this->assertNotEmpty($matches, 'Reset URL not found in email body');
+        $resetUrl = $matches[1];
+
+        // Simulate clicking the reset link
+        $crawler = self::$client->request('GET', $resetUrl);
+        $this->assertResponseRedirects('/reset-password/reset');
+        $crawler = self::$client->followRedirect();
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Reset your password');
+
+        // Submit the new password form
+        $form = $crawler->selectButton('Reset password')->form([
+            'change_password_form[plainPassword][first]' => 'NewPassword123-',
+            'change_password_form[plainPassword][second]' => 'NewPassword123-',
+        ]);
+        self::$client->submit($form);
+        $this->assertResponseRedirects('/login');
+
+        self::$client->followRedirect();
+        $this->assertResponseIsSuccessful();
+
+        // Verify that the password has been updated
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = self::$client->getContainer()->get(UserPasswordHasherInterface::class);
+        $user = $em->getRepository(Student::class)->findOneBy(['email' => 'reset_student@example.com']);
+
+        $this->assertTrue($hasher->isPasswordValid($user, 'NewPassword123-'), 'Password was not updated correctly');
+
+        // Verify that the reset request has been removed
+        $resetRequest = $em->getRepository(ResetPasswordRequest::class)->findOneBy(['user' => $user]);
+        $this->assertNull($resetRequest, 'Reset request was not removed after password reset');
+    }
+
+    /**
+     * Tests the password reset request process for a non-existing user.
+     * @return void
+     */
+    public function testRequestResetPasswordForNonExistingUser() : void
+    {
+        $crawler = self::$client->request('GET', '/reset-password');
+        $form = $crawler->selectButton('Send password reset email')->form([
+            'reset_password_request_form[email]' => 'nonexistent@example.com'
+        ]);
+        self::$client->submit($form);
+
+        // Assert that we are redirected to the check email page and no email is sent
+        $this->assertResponseRedirects('/reset-password/check-email');
+        $this->assertEmailCount(0);
+        $crawler = self::$client->followRedirect();
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Password Reset Email Sent');
+
+        //Check that no reset password request has been created
+        $container = self::$client->getContainer();
+        $em = $container->get('doctrine')->getManager();
+        $resetRequests = $em->getRepository(ResetPasswordRequest::class)->findAll();
+        $this->assertCount(0, $resetRequests, 'No reset requests should be created for non-existing users');
+    }
+
+    /**
+     * Tests the password reset process with an invalid token.
+     * @return void
+     */
+    public function testResetPasswordWithInvalidToken() : void
+    {
+        $crawler = self::$client->request('GET', '/reset-password/reset/invalidtoken1234');
+
+        // Check if there is redirect after saving token in session
+        $this->assertResponseRedirects('/reset-password/reset');
+        self::$client->followRedirect();
+
+        // Check if there is redirect after token validation has failed
+        $this->assertResponseRedirects('/reset-password');
+        self::$client->followRedirect();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('.alert');
+        $this->assertSelectorTextContains('.alert', 'There was a problem validating your password reset request');
+
+    }
+
+    /**
+     * Tests the password reset process with an expired token.
+     * @return void
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface
+     */
+    public function testResetPasswordWithExpiredToken() : void
+    {
+
+        $container = self::$client->getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'reset_student@example.com']);
+
+        // Generate a reset token for the user
+        /** @var ResetPasswordHelperInterface $resetPasswordHelper */
+        $resetPasswordHelper = $container->get(ResetPasswordHelperInterface::class);
+
+        $resetToken = $resetPasswordHelper->generateResetToken($user);
+
+        $em->flush();
+
+        // Manually expire the token by setting its expiration time to the past
+        $connection = $em->getConnection();
+        $connection->executeStatement(
+            'UPDATE reset_password_request SET expires_at = :past WHERE user_id = :id',
+            [
+                'past' => (new \DateTimeImmutable('-10 minutes'))->format('Y-m-d H:i:s'),
+                'id' => $user->getId()
+            ]
+        );
+
+        $publicToken = $resetToken->getToken();
+
+        self::$client->request('GET', '/reset-password/reset/' . $publicToken);
+        $this->assertResponseRedirects('/reset-password/reset');
+        self::$client->followRedirect();
+
+        $this->assertResponseRedirects('/reset-password');
+        self::$client->followRedirect();
+
+        $this->assertSelectorExists('.alert');
+        $this->assertSelectorTextContains('.alert', 'There was a problem validating your password reset request');
+
+    }
+
+    /**
+     * Tests the password reset process with a token that has already been used.
+     * @return void
+     */
+    public function testResetPasswordWithUsedToken()
+    {
+        $container = self::$client->getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'reset_student@example.com']);
+
+        // Generate a reset token for the user
+        /** @var ResetPasswordHelperInterface $resetPasswordHelper */
+        $resetPasswordHelper = $container->get(ResetPasswordHelperInterface::class);
+        $resetToken = $resetPasswordHelper->generateResetToken($user);
+        $em->flush();
+        $publicToken = $resetToken->getToken();
+
+        // Simulate using the token by resetting the password
+        self::$client->request('GET', '/reset-password/reset/' . $publicToken);
+        self::$client->followRedirect();
+        $crawler = self::$client->getCrawler();
+        $form = $crawler->selectButton('Reset password')->form([
+            'change_password_form[plainPassword][first]' => 'AnotherNewPassword123-',
+            'change_password_form[plainPassword][second]' => 'AnotherNewPassword123-',
+        ]);
+        self::$client->submit($form);
+        $this->assertResponseRedirects('/login');
+        self::$client->followRedirect();
+
+        // Attempt to reuse the same token
+        self::$client->request('GET', '/reset-password/reset/' . $publicToken);
+        $this->assertResponseRedirects('/reset-password/reset');
+        self::$client->followRedirect();
+        $this->assertResponseRedirects('/reset-password');
+        self::$client->followRedirect();
+        $this->assertSelectorExists('.alert');
+        $this->assertSelectorTextContains('.alert', 'There was a problem validating your password reset request');
+
+    }
+
+    /**
+     * Tests the password reset process with mismatched passwords.
+     * @return void
+     * @throws \SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface
+     */
+    public function testResetPasswordWithMismatchedPasswords()
+    {
+        $container = self::$client->getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'reset_student@example.com']);
+
+        // Generate a reset token for the user
+        /** @var ResetPasswordHelperInterface $resetPasswordHelper */
+        $resetPasswordHelper = $container->get(ResetPasswordHelperInterface::class);
+        $resetToken = $resetPasswordHelper->generateResetToken($user);
+        $em->flush();
+        $publicToken = $resetToken->getToken();
+        // Simulate using the token by resetting the password
+        self::$client->request('GET', '/reset-password/reset/' . $publicToken);
+        self::$client->followRedirect();
+        $crawler = self::$client->getCrawler();
+        $form = $crawler->selectButton('Reset password')->form([
+            'change_password_form[plainPassword][first]' => 'MismatchPassword123-',
+            'change_password_form[plainPassword][second]' => 'DifferentPassword123-',
+        ]);
+        self::$client->submit($form);
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('#change_password_form_plainPassword_first + .form-error-message');
+
+    }
+
+    /**
+     * Tests the password reset process with a weak password that does not meet criteria.
+     * @return void
+     * @throws \SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface
+     */
+    public function testResetPasswordWithWeakPassword() : void
+    {
+        $container = self::$client->getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'reset_student@example.com']);
+
+        // Generate a reset token for the user
+        /** @var ResetPasswordHelperInterface $resetPasswordHelper */
+        $resetPasswordHelper = $container->get(ResetPasswordHelperInterface::class);
+        $resetToken = $resetPasswordHelper->generateResetToken($user);
+        $em->flush();
+        $publicToken = $resetToken->getToken();
+        // Simulate using the token by resetting the password
+        self::$client->request('GET', '/reset-password/reset/' . $publicToken);
+        self::$client->followRedirect();
+        $crawler = self::$client->getCrawler();
+        $form = $crawler->selectButton('Reset password')->form([
+            'change_password_form[plainPassword][first]' => 'password', // Invalid password - regex does not match
+            'change_password_form[plainPassword][second]' => 'password',
+        ]);
+        self::$client->submit($form);
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('#change_password_form_plainPassword_first + .form-error-message');
+
+    }
+
+
+    /**
+     * Tests that multiple password reset requests are throttled to prevent abuse.
+     * @return void
+     */
+    public function testMultipleResetRequestsThrottle() : void
+    {
+        $container = self::$client->getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'reset_student@example.com']);
+        $crawler = self::$client->request('GET', '/reset-password');
+        $form = $crawler->selectButton('Send password reset email')->form([
+            'reset_password_request_form[email]' => 'reset_student@example.com']);
+        // Send multiple requests in quick succession
+        for ($i = 0; $i < 5; $i++) {
+            self::$client->submit($form);
+            // Delay to simulate rapid requests
+            usleep(100000);
+        }
+        // Check that only one reset request exists
+        $resetRequests = $em->getRepository(ResetPasswordRequest::class)->findBy(['user' => $user]);
+        $this->assertCount(1, $resetRequests, 'Only one reset request should be created due to throttling');
+    }
+
+
+}


### PR DESCRIPTION
**Summary:**
This pull request introduces the reset password flow.

**Key changes:**

1. New ResetPasswordController with request, check-email and reset endpoints.
2. Added ResetPasswordRequest entity + repository (SymfonyCasts bundle).
3. Created forms: ChangePasswordFormType and ResetPasswordRequestFormType with validation.
4. New email template reset_password_email.html.twig with reset link.
5. Integrated token generation/validation with ResetPasswordHelperInterface.
6. Functional tests added for request, email sending, reset with valid/invalid/expired token.

**Testing:**
All PHPUnit tests pass.
Emails verified in Mailpit (reset link works).
Manually tested full flow in dev: request → email → reset → login with new password.
