### PR TITLE
Feat: Introduce UserType enum and integrate it across the user domain

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -41,10 +42,19 @@ class RegistrationController extends AbstractController
         UserRegistrationHandler $handler,
     ): JsonResponse
     {
-        $dto = $serializer->deserialize(
-            $request->getContent(),
-            RegisterUserRequest::class,
-            'json');
+        try{
+            $dto = $serializer->deserialize(
+                $request->getContent(),
+                RegisterUserRequest::class,
+                'json');
+        } catch (InvalidArgumentException | \ValueError $e) {
+            return new JsonResponse([
+                'status' => 'error',
+                'code' => 'INVALID_PAYLOAD',
+                'message' => 'Invalid request data format.'
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
         $errors = $validator->validate($dto);
 
         if (count($errors) > 0) {

--- a/src/DTO/RegisterUserRequest.php
+++ b/src/DTO/RegisterUserRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\DTO;
 
+use App\Enum\UserType;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -32,8 +33,7 @@ class RegisterUserRequest
         public readonly string $lastName,
 
         #[Assert\NotBlank]
-        #[Assert\Choice(['student', 'teacher'])]
-        public readonly string $type,
+        public readonly ?UserType $type,
     ) {}
 
 }

--- a/src/Entity/Student.php
+++ b/src/Entity/Student.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Enum\UserType;
 use App\Repository\StudentRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -25,9 +26,9 @@ class Student extends User
      * Returns the type identifier for this user,
      * distinguish between user types.
      */
-    public function getType(): string
+    public function getType(): UserType
     {
-        return 'student';
+        return UserType::STUDENT;
     }
 
     /**

--- a/src/Entity/Teacher.php
+++ b/src/Entity/Teacher.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Enum\UserType;
 use App\Repository\TeacherRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -92,9 +93,9 @@ class Teacher extends User
      * Returns the type identifier for this user,
      * distinguish between user types.
      */
-    public function getType(): string
+    public function getType(): UserType
     {
-        return 'teacher';
+        return UserType::TEACHER;
     }
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Enum\UserType;
 use App\Repository\UserRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -166,7 +167,7 @@ abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
      * Gets user's type.
      * @return string
      */
-    abstract public function getType(): string;
+    abstract public function getType(): UserType;
 
     public function getCreatedAt(): ?\DateTimeImmutable
     {

--- a/src/Enum/UserType.php
+++ b/src/Enum/UserType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum UserType : string
+{
+    case STUDENT = 'student';
+    case TEACHER = 'teacher';
+
+}

--- a/src/EventListener/JWTAuthenticationListener.php
+++ b/src/EventListener/JWTAuthenticationListener.php
@@ -24,21 +24,13 @@ class JWTAuthenticationListener
         if (!$user instanceof UserInterface) {
             return;
         }
-        $type = null;
-        if ($user instanceof Student){
-            $type = 'student';
-        } elseif ($user instanceof Teacher){
-            $type = 'teacher';
-        } else {
-            $type = 'user';
-        }
 
         $userData = [
             'id' => $user->getId(),
             'email' => $user->getEmail(),
             'name' => $user->getName(),
             'lastName' => $user->getLastName(),
-            'type' => $type,
+            'type' => $user->getType()->value,
         ];
 
         $data = $event->getData();

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -6,6 +6,7 @@ use App\DTO\RegisterUserRequest;
 use App\Entity\Student;
 use App\Entity\Teacher;
 use App\Entity\User;
+use App\Enum\UserType;
 
 /**
  * Factory to create User entities from DTOs
@@ -15,14 +16,15 @@ class UserFactory
     public function createFromDto(RegisterUserRequest $dto) : User
     {
         $user = match ($dto->type) {
-            'student' => new Student(),
-            'teacher' => new Teacher(),
-            default => throw new \InvalidArgumentException('Invalid user type: ' . $dto->type),
+            UserType::STUDENT => new Student(),
+            UserType::TEACHER => new Teacher(),
+            default => throw new \InvalidArgumentException('Invalid user type: ' . $dto->type->value),
         };
 
         $roles = match ($dto->type) {
-            'student' => ['ROLE_USER','ROLE_STUDENT'],
-            'teacher' => ['ROLE_USER','ROLE_TEACHER'],
+            UserType::STUDENT => ['ROLE_USER','ROLE_STUDENT'],
+            UserType::TEACHER => ['ROLE_USER','ROLE_TEACHER'],
+            default => throw new \Exception('Unexpected match value'),
         };
 
         $user->setEmail($dto->email)


### PR DESCRIPTION
**Summary**
This PR introduces `UserType` enum to replace string-based user type handling across the entire user domain. The goal is to  reduce string comparisons which are prone to errors  and also standardize user type in application.

**Key changes**
1. Added `UserType` backed enum (`student`, `teacher`).
2. Updated `RegisterUserRequest` DTO to use `UserType` instead of string.
3. Refactored `UserFactory` to create the correct user entity based on the enum value.
4. Updated `JWTAuthenticationListener` to include enum-based user type in the token payload.
5. Updated `User`, `Student`, `Teacher` entities to work with enum-based user types.
6. Added error handling for invalid enum values in `RegistrationController`.

**Testing**
- All existing tests pass
- Updated registration flow to correctly handle invalid enum values
- Manually tested login/registration with both Student and Teacher accounts
