### PR TITLE
Refactor: Add EmailServiceInterface and update listener to depend on abstraction.

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,6 +24,7 @@ services:
             - '../src/Kernel.php'
             - '../src/Legacy/'
 
+    App\Service\EmailServiceInterface: '@App\Service\EmailService'
 
     App\EventListener\JWTAuthenticationListener:
         tags:

--- a/src/EventListener/SendEmailVerificationListener.php
+++ b/src/EventListener/SendEmailVerificationListener.php
@@ -4,6 +4,7 @@ namespace App\EventListener;
 
 use App\Event\UserRegisteredEvent;
 use App\Service\EmailService;
+use App\Service\EmailServiceInterface;
 
 /**
  * Listener to send email verification upon user registration.
@@ -11,12 +12,11 @@ use App\Service\EmailService;
 class SendEmailVerificationListener
 {
 
-    public function __construct(private EmailService $emailService) {}
+    public function __construct(private EmailServiceInterface $emailService) {}
 
     public function onUserRegistered(UserRegisteredEvent $event)
     {
-        $user = $event->getUser();
-        $this->emailService->sendEmailVerification($user);
+        $this->emailService->sendEmailVerification( $event->getUser());
     }
 
 }

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * Service to handle email sending functionalities.
  */
-class EmailService
+class EmailService implements EmailServiceInterface
 {
     public function __construct(
         private MailerInterface $mailer,

--- a/src/Service/EmailServiceInterface.php
+++ b/src/Service/EmailServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+
+interface EmailServiceInterface
+{
+    public function sendEmailVerification(User $user): void;
+}


### PR DESCRIPTION
**Summary**
This PR introduces an `EmailServiceInterface `to abstract email sending logic and decouple domain events from services.


**Key changes**
1. Added `EmailServiceInterface `defining the email sending contract.
2. Updated existing `EmailService `to implement the interface.
3. Adjusted `SendEmailVerificationListener `to depend on the interface.

**Benefits**
- Enables easy switching between synchronous and asynchronous email delivery in the furture.
- Improves testability.
- Aligns with SOLID principles.

**Testing**
All PHPUnit tests pass.
