### PR TITLE
Tests: Add unit tests for EmailService (MailerInterface mocked)

### DIFF
--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -10,8 +10,8 @@ use App\Service\EmailServiceInterface;
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Email;
 
 class EmailServiceTest extends TestCase
 {
@@ -45,7 +45,7 @@ class EmailServiceTest extends TestCase
 
         $this->mailer->expects($this->once())
             ->method('send')
-            ->with($this->callback(function (Email $email) use ($student) {
+            ->with($this->callback(function (TemplatedEmail $email) use ($student) {
                 $this->assertSame('student@example.com', $email->getTo()[0]->getAddress());
                 $this->assertSame('mail/verification_email_student.html.twig', $email->getHtmlTemplate());
                 $context = $email->getContext();
@@ -73,7 +73,7 @@ class EmailServiceTest extends TestCase
         $this->mailer
             ->expects($this->once())
             ->method('send')
-            ->with($this->callback(function (Email $email) use ($teacher) {
+            ->with($this->callback(function (TemplatedEmail $email) use ($teacher) {
                 $this->assertSame('teacher@example.com', $email->getTo()[0]->getAddress());
                 $this->assertSame('mail/verification_email_teacher.html.twig', $email->getHtmlTemplate());
                 $context = $email->getContext();

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -41,7 +41,6 @@ class EmailServiceTest extends TestCase
         $student->setEmail('student@example.com')
             ->setName('Test')
             ->setLastName('Student')
-            ->setIsVerified(false)
             ->setVerificationToken('verification-token-123')
             ->setVerificationTokenExpiresAt(new DateTimeImmutable('+1 day'));
 

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -18,7 +18,6 @@ class EmailServiceTest extends TestCase
     private MailerInterface $mailer;
     private EmailServiceInterface $emailService;
 
-
     protected function setUp(): void
     {
         $this->mailer = $this->createMock(MailerInterface::class);

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -22,7 +22,7 @@ class EmailServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->mailer = $this->createMock(MailerInterface::class);
-        $this->emailService  = new EmailService(
+        $this->emailService = new EmailService(
             $this->mailer,
             'test@example.com',
             'Test Sender',

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Student;
+use App\Entity\Teacher;
+use App\Entity\User;
+use App\Service\EmailService;
+use App\Service\EmailServiceInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+
+class EmailServiceTest extends TestCase
+{
+    private MailerInterface $mailer;
+    private EmailServiceInterface $emailService;
+
+
+    protected function setUp() : void
+    {
+        $this->mailer = $this->createMock(MailerInterface::class);
+        $this->emailService  = new EmailService(
+            $this->mailer,
+            'test@example.com',
+            'Test Sender',
+            'http://frontend.test',
+        );
+    }
+
+    /**
+     * Tests sending email verification for a Student user.
+     * @return void
+     */
+    #[Group('service')]
+    public function testSendEmailVerificationForStudent()
+    {
+        $student = new Student();
+        $student->setEmail('student@example.com')
+            ->setName('Test')
+            ->setLastName('Student')
+            ->setIsVerified(false)
+            ->setVerificationToken('verification-token-123')
+            ->setVerificationTokenExpiresAt(new DateTimeImmutable('+1 day'));
+
+        $this->mailer->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email) use ($student) {
+                $this->assertSame('student@example.com', $email->getTo()[0]->getAddress());
+                $this->assertSame('mail/verification_email_student.html.twig', $email->getHtmlTemplate());
+                $context = $email->getContext();
+                $this->assertArrayHasKey('verificationUrl', $context);
+                $this->assertStringContainsString('verify-email?token=verification-token-123', $context['verificationUrl']);
+                return true;
+            }));
+
+        $this->emailService->sendEmailVerification($student);
+    }
+
+    /**
+     * Tests sending email verification for a Teacher user.
+     * @return void
+     */
+    #[Group('service')]
+    public function testSendEmailVerificationForTeacher(): void
+    {
+        $teacher = (new Teacher())
+            ->setEmail('teacher@example.com')
+            ->setName('Test')
+            ->setLastName('Teacher')
+            ->setVerificationToken('verification-token-123')
+            ->setVerificationTokenExpiresAt(new DateTimeImmutable('+1 day'));
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email) use ($teacher) {
+                $this->assertSame('teacher@example.com', $email->getTo()[0]->getAddress());
+                $this->assertSame('mail/verification_email_teacher.html.twig', $email->getHtmlTemplate());
+                $context = $email->getContext();
+                $this->assertArrayHasKey('verificationUrl', $context);
+                $this->assertStringContainsString('verify-email?token=verification-token-123', $context['verificationUrl']);
+                return true;
+            }));
+
+        $this->emailService->sendEmailVerification($teacher);
+    }
+
+    /**
+     * Tests sending email verification for an unsupported user type.
+     * @return void
+     */
+    #[Group('service')]
+    public function testSendEmailVerificationUnsupportedUserType(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        $unsupportedUser = $this->getMockBuilder(User::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->emailService->sendEmailVerification($unsupportedUser);
+    }
+}

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -61,7 +61,6 @@ class EmailServiceTest extends TestCase
 
     /**
      * Tests sending email verification for a Teacher user.
-     * @return void
      */
     #[Group('service')]
     public function testSendEmailVerificationForTeacher(): void

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -19,7 +19,7 @@ class EmailServiceTest extends TestCase
     private EmailServiceInterface $emailService;
 
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->mailer = $this->createMock(MailerInterface::class);
         $this->emailService  = new EmailService(

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -88,7 +88,6 @@ class EmailServiceTest extends TestCase
 
     /**
      * Tests sending email verification for an unsupported user type.
-     * @return void
      */
     #[Group('service')]
     public function testSendEmailVerificationUnsupportedUserType(): void

--- a/tests/Service/EmailServiceTest.php
+++ b/tests/Service/EmailServiceTest.php
@@ -35,7 +35,7 @@ class EmailServiceTest extends TestCase
      * @return void
      */
     #[Group('service')]
-    public function testSendEmailVerificationForStudent()
+    public function testSendEmailVerificationForStudent(): void
     {
         $student = new Student();
         $student->setEmail('student@example.com')


### PR DESCRIPTION
**Summary**
This PR adds PHPUnit unit tests for `EmailService`, ensuring that the email verification logic works correctly for different user types and that invalid cases are properly handled. 

**Key changes**
- Added `EmailServiceTest` (unit tests for email sending service).
- Mocked `MailerInterface` to avoid sending real emails.
- Added tests include:
  - Correct email generation for `Student`
  - Correct email generation for `Teacher`.
  - Exception thrown for unsupported user type.

**Testing**
- All PHPUnit tests pass.
