### PR TITLE
Feat: Implement Full Password Reset Flow (Backend Only)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "symfony/validator": "6.3.*",
         "symfony/webpack-encore-bundle": "^2.2",
         "symfony/yaml": "6.3.*",
-        "symfonycasts/reset-password-bundle": "^1.23",
         "symfonycasts/verify-email-bundle": "*",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "161e0202753165b7e3622cc7f76fdd26",
+    "content-hash": "1f4badb38442ddc2738d0c008bc17f7b",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -6871,53 +6871,6 @@
             "time": "2024-01-23T14:35:58+00:00"
         },
         {
-            "name": "symfonycasts/reset-password-bundle",
-            "version": "v1.23.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/SymfonyCasts/reset-password-bundle.git",
-                "reference": "beff941f4d7f8ad7fbd32e482e13acbcefa0dde4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/SymfonyCasts/reset-password-bundle/zipball/beff941f4d7f8ad7fbd32e482e13acbcefa0dde4",
-                "reference": "beff941f4d7f8ad7fbd32e482e13acbcefa0dde4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1.10",
-                "symfony/config": "^5.4 | ^6.0 | ^7.0",
-                "symfony/dependency-injection": "^5.4 | ^6.0 | ^7.0",
-                "symfony/deprecation-contracts": "^2.2 | ^3.0",
-                "symfony/http-kernel": "^5.4 | ^6.0 | ^7.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^1.0",
-                "doctrine/doctrine-bundle": "^2.8",
-                "doctrine/orm": "^2.13",
-                "symfony/framework-bundle": "^5.4 | ^6.0 | ^7.0",
-                "symfony/phpunit-bridge": "^5.4 | ^6.0 | ^7.0",
-                "symfony/process": "^6.4 | ^7.0 | ^7.1",
-                "symfonycasts/internal-test-helpers": "dev-main"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-4": {
-                    "SymfonyCasts\\Bundle\\ResetPassword\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Symfony bundle that adds password reset functionality.",
-            "support": {
-                "issues": "https://github.com/SymfonyCasts/reset-password-bundle/issues",
-                "source": "https://github.com/SymfonyCasts/reset-password-bundle/tree/v1.23.2"
-            },
-            "time": "2025-06-27T20:32:48+00:00"
-        },
-        {
             "name": "symfonycasts/verify-email-bundle",
             "version": "v1.17.3",
             "source": {
@@ -9558,5 +9511,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,7 +12,6 @@ return [
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle::class => ['all' => true],
-    SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],

--- a/config/packages/reset_password.yaml
+++ b/config/packages/reset_password.yaml
@@ -1,5 +1,0 @@
-symfonycasts_reset_password:
-    # Replace symfonycasts.reset_password.fake_request_repository with the full
-    # namespace of the password reset request repository after it has been created.
-    # i.e. App\Repository\ResetPasswordRequestRepository
-    request_password_repository: App\Repository\ResetPasswordRequestRepository

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -42,6 +42,11 @@ services:
     App\EventListener\SendEmailVerificationListener:
         tags:
             - { name: kernel.event_listener, event: 'user.registered', method: onUserRegistered }
+
+    App\EventListener\SendPasswordResetListener:
+        tags:
+            - { name: kernel.event_listener, event: 'user.reset_password_requested'}
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 

--- a/migrations/Version20251130170656.php
+++ b/migrations/Version20251130170656.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251130170656 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql(<<<'SQL'
+            ALTER TABLE reset_password_request CHANGE selector selector VARCHAR(255) NOT NULL, CHANGE hashed_token hashed_token VARCHAR(255) NOT NULL, CHANGE requested_at created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql(<<<'SQL'
+            ALTER TABLE reset_password_request CHANGE hashed_token hashed_token VARCHAR(100) NOT NULL, CHANGE selector selector VARCHAR(20) NOT NULL, CHANGE created_at requested_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)'
+        SQL);
+    }
+}

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -3,16 +3,20 @@
 namespace App\Controller;
 
 
-use App\Handler\PasswordResetHandler;
+use App\DTO\ResetPassword;
+use App\Handler\PasswordResetFinalHandler;
+use App\Handler\PasswordResetRequestHandler;
+use App\Handler\ResetPasswordValidationHandler;
 use Exception;
-use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 
 class ResetPasswordController extends AbstractController
@@ -29,8 +33,8 @@ class ResetPasswordController extends AbstractController
      */
     #[Route('/api/request-reset-password', name: 'api_request_reset_password', methods: ['POST'])]
     public function requestResetPassword(
-        Request  $request,
-        PasswordResetHandler $handler,
+        Request                     $request,
+        PasswordResetRequestHandler $handler,
     ): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
@@ -52,6 +56,103 @@ class ResetPasswordController extends AbstractController
         return new JsonResponse([
             'status' => 'success',
             'message' => 'If an account with that email exists, a password reset link has been sent.'
+        ], Response::HTTP_OK);
+    }
+
+    #[Route('/api/validate-reset-token', name: 'api_validate_reset_token', methods: ['GET'])]
+    public function validateToken(
+        Request $request,
+        ResetPasswordValidationHandler $validator,
+    ) : JsonResponse
+    {
+        $token = $request->get('token');
+        $selector = $request->get('selector');
+
+        if (!$token || !$selector) {
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => 'Missing token or selector.'
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+
+            $resetPasswordRequest = $validator->validate(
+                $selector,
+                $token
+            );
+
+        } catch (InvalidArgumentException $e) {
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => 'Invalid or expired token.'
+            ], Response::HTTP_BAD_REQUEST);
+
+        }
+
+         return new JsonResponse([
+             'status' => 'success',
+             'message' => 'Token is valid.'
+         ], Response::HTTP_OK);
+    }
+
+
+    #[Route('/api/reset-password', name: 'api_reset_password', methods: ['POST'])]
+    public function resetPassword(
+        Request  $request,
+        SerializerInterface  $serializer,
+        PasswordResetFinalHandler $handler,
+        ValidatorInterface $validator,
+    ) : JsonResponse
+    {
+        try{
+            $dto = $serializer->deserialize(
+                $request->getContent(),
+                ResetPassword::class,
+                'json');
+        } catch (InvalidArgumentException | \ValueError $e) {
+            return new JsonResponse([
+                'status' => 'error',
+                'code' => 'INVALID_PAYLOAD',
+                'message' => 'Invalid request data format.'
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $errors = $validator->validate($dto);
+
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+            return new JsonResponse([
+                'status' => 'error',
+                'code' => 'INVALID_PAYLOAD',
+                'message' => 'Invalid request data format.',
+                'errors' => $errorMessages
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $handler->handle($dto);
+        } catch (InvalidArgumentException $e) {
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => 'Invalid reset password request: ' . $e->getMessage()
+            ], Response::HTTP_BAD_REQUEST);
+        } catch (Exception $e) {
+            $this->logger->error('Password reset failed', [
+                'exception' => $e,
+                'message' => $e->getMessage(),
+            ]);
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => 'Failed to reset password.'
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+        return new JsonResponse([
+            'status' => 'success',
+            'message' => 'Password has been reset successfully.'
         ], Response::HTTP_OK);
     }
 

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -6,7 +6,7 @@ namespace App\Controller;
 use App\DTO\ResetPassword;
 use App\Handler\PasswordResetFinalHandler;
 use App\Handler\PasswordResetRequestHandler;
-use App\Handler\ResetPasswordValidationHandler;
+use App\Handler\PasswordResetValidationHandler;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -62,7 +62,7 @@ class ResetPasswordController extends AbstractController
     #[Route('/api/validate-reset-token', name: 'api_validate_reset_token', methods: ['GET'])]
     public function validateToken(
         Request $request,
-        ResetPasswordValidationHandler $validator,
+        PasswordResetValidationHandler $validator,
     ) : JsonResponse
     {
         $token = $request->get('token');

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Controller;
+
+
+use App\Handler\PasswordResetHandler;
+use Exception;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+
+
+class ResetPasswordController extends AbstractController
+{
+    public function __construct(
+        private LoggerInterface $logger
+    ){}
+
+    /**
+     * Handles password reset request API endpoint
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    #[Route('/api/request-reset-password', name: 'api_request_reset_password', methods: ['POST'])]
+    public function requestResetPassword(
+        Request  $request,
+        PasswordResetHandler $handler,
+    ): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $email = $data['email'] ?? null;
+
+        try {
+            $handler->handle($email);
+        } catch (InvalidArgumentException $e) {
+            $this->logger->info('Password reset requested for non-existing email.', [
+                'email' => $email,
+            ]);
+        } catch (Exception $e) {
+            $this->logger->error('Password reset request failed', [
+                'exception' => $e,
+                'message' => $e->getMessage(),
+            ]);
+        }
+
+        return new JsonResponse([
+            'status' => 'success',
+            'message' => 'If an account with that email exists, a password reset link has been sent.'
+        ], Response::HTTP_OK);
+    }
+
+}
+

--- a/src/DTO/ResetPassword.php
+++ b/src/DTO/ResetPassword.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\DTO;
+
+use App\Enum\UserType;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Data Transfer Object for reset password
+ */
+readonly class ResetPassword
+{
+    public function __construct(
+
+        #[Assert\NotBlank]
+        public string $selector,
+
+        #[Assert\NotBlank]
+        public string $token,
+
+        #[Assert\NotBlank]
+        #[Assert\Regex(
+            pattern: '/^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[\W_]).{8,}$/',
+            message: 'Password must contain an uppercase letter, lowercase letter, number and special character.'
+        )]
+        public string $password,
+
+        #[Assert\NotBlank]
+        #[Assert\EqualTo(propertyPath: 'password', message: 'Password confirmation does not match.')]
+        public string $passwordConfirmation
+    ) {}
+
+}

--- a/src/DTO/ResetPassword.php
+++ b/src/DTO/ResetPassword.php
@@ -2,7 +2,6 @@
 
 namespace App\DTO;
 
-use App\Enum\UserType;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**

--- a/src/Entity/ResetPasswordRequest.php
+++ b/src/Entity/ResetPasswordRequest.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\ResetPasswordRequestRepository;
+use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
@@ -28,23 +29,25 @@ class ResetPasswordRequest
     private string $selector;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    private \DateTimeImmutable $expiresAt;
+    private DateTimeImmutable $expiresAt;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    private \DateTimeImmutable $createdAt;
+    private DateTimeImmutable $createdAt;
+
+    private ?string $plainToken = null;
 
     public function __construct(
         User $user,
         string $hashedToken,
         string $selector,
-        \DateTimeImmutable $expiresAt,
+        DateTimeImmutable $expiresAt,
     )
     {
         $this->user = $user;
         $this->hashedToken = $hashedToken;
         $this->selector = $selector;
         $this->expiresAt = $expiresAt;
-        $this->createdAt = new \DateTimeImmutable();
+        $this->createdAt = new DateTimeImmutable();
     }
 
 
@@ -70,6 +73,22 @@ class ResetPasswordRequest
 
     public function isExpired(): bool
     {
-        return $this->expiresAt <= new \DateTimeImmutable();
+        return $this->expiresAt <= new DateTimeImmutable();
+    }
+
+    public function setPlainToken(string $plainToken) : self
+    {
+        $this->plainToken = $plainToken;
+        return $this;
+    }
+
+    public function getPlainToken(): ?string
+    {
+        return $this->plainToken;
+    }
+
+    public function getExpiresAt() : DateTimeImmutable
+    {
+        return $this->expiresAt;
     }
 }

--- a/src/Entity/ResetPasswordRequest.php
+++ b/src/Entity/ResetPasswordRequest.php
@@ -8,9 +8,8 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
 
 #[ORM\Entity(repositoryClass: ResetPasswordRequestRepository::class)]
-class ResetPasswordRequest implements ResetPasswordRequestInterface
+class ResetPasswordRequest
 {
-    use ResetPasswordRequestTrait;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -21,19 +20,56 @@ class ResetPasswordRequest implements ResetPasswordRequestInterface
     #[ORM\JoinColumn(nullable: false)]
     private ?User $user = null;
 
-    public function __construct(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $hashedToken;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $selector;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        User $user,
+        string $hashedToken,
+        string $selector,
+        \DateTimeImmutable $expiresAt,
+    )
     {
         $this->user = $user;
-        $this->initialize($expiresAt, $selector, $hashedToken);
+        $this->hashedToken = $hashedToken;
+        $this->selector = $selector;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = new \DateTimeImmutable();
     }
+
 
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getUser(): object
+    public function getUser(): User
     {
         return $this->user;
+    }
+
+    public function getSelector(): string
+    {
+        return $this->selector;
+    }
+
+    public function getHashedToken(): string
+    {
+        return $this->hashedToken;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expiresAt <= new \DateTimeImmutable();
     }
 }

--- a/src/Event/ResetPasswordRequestedEvent.php
+++ b/src/Event/ResetPasswordRequestedEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Event;
+
+use App\Entity\ResetPasswordRequest;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event triggered when a password reset is requested.
+ */
+class ResetPasswordRequestedEvent extends Event
+{
+    public const NAME = 'user.reset_password_requested'
+;
+
+    public function __construct(
+        private readonly ResetPasswordRequest $resetPasswordRequest
+    ) {}
+
+  public function getResetPasswordRequest(): ResetPasswordRequest
+  {
+      return $this->resetPasswordRequest;
+  }
+
+}

--- a/src/Event/ResetPasswordRequestedEvent.php
+++ b/src/Event/ResetPasswordRequestedEvent.php
@@ -16,9 +16,9 @@ class ResetPasswordRequestedEvent extends Event
         private readonly ResetPasswordRequest $resetPasswordRequest
     ) {}
 
-  public function getResetPasswordRequest(): ResetPasswordRequest
-  {
-      return $this->resetPasswordRequest;
-  }
+    public function getResetPasswordRequest(): ResetPasswordRequest
+    {
+        return $this->resetPasswordRequest;
+    }
 
 }

--- a/src/Event/ResetPasswordRequestedEvent.php
+++ b/src/Event/ResetPasswordRequestedEvent.php
@@ -10,8 +10,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class ResetPasswordRequestedEvent extends Event
 {
-    public const NAME = 'user.reset_password_requested'
-;
+    public const NAME = 'user.reset_password_requested';
 
     public function __construct(
         private readonly ResetPasswordRequest $resetPasswordRequest

--- a/src/EventListener/SendResetPasswordListener.php
+++ b/src/EventListener/SendResetPasswordListener.php
@@ -6,7 +6,7 @@ use App\Event\ResetPasswordRequestedEvent;
 use App\Service\EmailServiceInterface;
 
 /**
-* Listener to send reset password email when requested.
+ * Listener to send reset password email when requested.
  */
 class SendResetPasswordListener
 {

--- a/src/EventListener/SendResetPasswordListener.php
+++ b/src/EventListener/SendResetPasswordListener.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Event\ResetPasswordRequestedEvent;
+use App\Service\EmailServiceInterface;
+
+/**
+* Listener to send reset password email when requested.
+ */
+class SendResetPasswordListener
+{
+
+    public function __construct(private EmailServiceInterface $emailService) {}
+
+    public function __invoke(ResetPasswordRequestedEvent $event)
+    {
+        $this->emailService->sendResetPasswordEmail($event->getResetPasswordRequest());
+    }
+
+}

--- a/src/Handler/PasswordResetFinalHandler.php
+++ b/src/Handler/PasswordResetFinalHandler.php
@@ -16,7 +16,7 @@ class PasswordResetFinalHandler
 {
     public function __construct(
         private EntityManagerInterface $em,
-        private ResetPasswordValidationHandler $validator,
+        private PasswordResetValidationHandler $validator,
         private UserPasswordHasherInterface $hasher
     ) {}
 

--- a/src/Handler/PasswordResetFinalHandler.php
+++ b/src/Handler/PasswordResetFinalHandler.php
@@ -10,7 +10,7 @@ use RuntimeException;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
-* Handles password reset
+ * Handles password reset
  */
 class PasswordResetFinalHandler
 {

--- a/src/Handler/PasswordResetFinalHandler.php
+++ b/src/Handler/PasswordResetFinalHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Handler;
+
+use App\DTO\ResetPassword;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+* Handles password reset
+ */
+class PasswordResetFinalHandler
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ResetPasswordValidationHandler $validator,
+        private UserPasswordHasherInterface $hasher
+    ) {}
+
+    /**
+     * @throws Exception
+     */
+    public function handle(ResetPassword $dto) : void
+    {
+        $resetPasswordRequest = $this->validator->validate($dto->selector, $dto->token);
+
+        $user = $resetPasswordRequest->getUser();
+
+        $hashedPassword = $this->hasher->hashPassword($user, $dto->password);
+        $user->setPassword($hashedPassword);
+
+        try {
+            $this->em->remove($resetPasswordRequest);
+            $this->em->flush();
+        } catch (Exception $e) {
+            throw new RuntimeException('Failed to reset password: ' . $e->getMessage());
+        }
+    }
+
+}

--- a/src/Handler/PasswordResetHandler.php
+++ b/src/Handler/PasswordResetHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Handler;
+
+use App\Entity\ResetPasswordRequest;
+use App\Entity\User;
+use App\Event\ResetPasswordRequestedEvent;
+use App\Service\TokenGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Handles user registration process
+ */
+class PasswordResetHandler
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private EventDispatcherInterface $dispatcher,
+        private TokenGeneratorInterface $tokenGenerator,
+    ) {}
+
+    /**
+     * @throws Exception
+     */
+    public function handle(string $email) : void
+    {
+        $existingUser = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        if (!$existingUser) {
+            throw new InvalidArgumentException('No user found with email: ' . $email);
+        }
+
+        $selector = $this->tokenGenerator->generateSelector();
+        $plainToken = $this->tokenGenerator->generateToken();
+
+        $hashedToken = password_hash($plainToken, PASSWORD_ARGON2ID);
+
+        $resetPasswordRequest = new ResetPasswordRequest(
+            user: $existingUser,
+            hashedToken: $hashedToken,
+            selector: $selector,
+            expiresAt: (new \DateTimeImmutable())->modify('+1 hour')
+        );
+
+        try {
+            $this->em->persist($resetPasswordRequest);
+            $this->em->flush();
+        } catch (Exception $e) {
+            throw new RuntimeException('Failed to create reset password request: ' . $e->getMessage());
+        }
+
+        try {
+            $event = new ResetPasswordRequestedEvent($resetPasswordRequest);
+            $this->dispatcher->dispatch($event, ResetPasswordRequestedEvent::NAME);
+        } catch (Exception $e) {
+            throw new RuntimeException('Failed to dispatch reset password event: ' . $e->getMessage());
+        }
+    }
+
+}

--- a/src/Handler/PasswordResetHandler.php
+++ b/src/Handler/PasswordResetHandler.php
@@ -45,6 +45,8 @@ class PasswordResetHandler
             expiresAt: (new \DateTimeImmutable())->modify('+1 hour')
         );
 
+        $resetPasswordRequest->setPlainToken($plainToken);
+
         try {
             $this->em->persist($resetPasswordRequest);
             $this->em->flush();

--- a/src/Handler/PasswordResetRequestHandler.php
+++ b/src/Handler/PasswordResetRequestHandler.php
@@ -13,9 +13,9 @@ use RuntimeException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Handles user registration process
+ * Handles password reset request process
  */
-class PasswordResetHandler
+class PasswordResetRequestHandler
 {
     public function __construct(
         private EntityManagerInterface $em,

--- a/src/Handler/PasswordResetRequestHandler.php
+++ b/src/Handler/PasswordResetRequestHandler.php
@@ -33,6 +33,12 @@ class PasswordResetRequestHandler
             throw new InvalidArgumentException('No user found with email: ' . $email);
         }
 
+        $existingRequest = $this->em->getRepository(ResetPasswordRequest::class)->findActiveByUser($existingUser);
+
+        if ($existingRequest !== null) {
+            $this->em->remove($existingRequest);
+        }
+
         $selector = $this->tokenGenerator->generateSelector();
         $plainToken = $this->tokenGenerator->generateToken();
 

--- a/src/Handler/PasswordResetValidationHandler.php
+++ b/src/Handler/PasswordResetValidationHandler.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 /**
  * Handles reset password token validation.
  */
-class ResetPasswordValidationHandler
+class PasswordResetValidationHandler
 {
     public function __construct(
         private ResetPasswordRequestRepository $repository,

--- a/src/Handler/ResetPasswordValidationHandler.php
+++ b/src/Handler/ResetPasswordValidationHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Handler;
+
+use App\Entity\ResetPasswordRequest;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use InvalidArgumentException;
+
+
+/**
+ * Handles reset password token validation
+ */
+class ResetPasswordValidationHandler
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {}
+
+    /**
+     * @throws Exception
+     */
+    public function validate( string $selector, string $token) : ResetPasswordRequest
+    {
+        $resetPasswordRequest = $this->em->getRepository(ResetPasswordRequest::class)
+            ->findOneBy(['selector' => $selector]);
+
+        if (!$resetPasswordRequest) {
+            throw new InvalidArgumentException('Invalid reset password token.');
+        }
+
+        if ($resetPasswordRequest->isExpired()) {
+            throw new InvalidArgumentException('Reset password token has expired.');
+        }
+
+        if (password_verify($token, $resetPasswordRequest->getHashedToken())) {
+            throw new InvalidArgumentException('Invalid reset password token.');
+        }
+
+        return $resetPasswordRequest;
+    }
+
+}

--- a/src/Handler/ResetPasswordValidationHandler.php
+++ b/src/Handler/ResetPasswordValidationHandler.php
@@ -3,27 +3,24 @@
 namespace App\Handler;
 
 use App\Entity\ResetPasswordRequest;
-use Doctrine\ORM\EntityManagerInterface;
-use Exception;
+use App\Repository\ResetPasswordRequestRepository;
 use InvalidArgumentException;
 
-
 /**
- * Handles reset password token validation
+ * Handles reset password token validation.
  */
 class ResetPasswordValidationHandler
 {
     public function __construct(
-        private EntityManagerInterface $em,
+        private ResetPasswordRequestRepository $repository,
     ) {}
 
     /**
-     * @throws Exception
+     * @throws InvalidArgumentException
      */
-    public function validate( string $selector, string $token) : ResetPasswordRequest
+    public function validate(string $selector, string $token): ResetPasswordRequest
     {
-        $resetPasswordRequest = $this->em->getRepository(ResetPasswordRequest::class)
-            ->findOneBy(['selector' => $selector]);
+        $resetPasswordRequest = $this->repository->findOneBySelector($selector);
 
         if (!$resetPasswordRequest) {
             throw new InvalidArgumentException('Invalid reset password token.');
@@ -33,11 +30,10 @@ class ResetPasswordValidationHandler
             throw new InvalidArgumentException('Reset password token has expired.');
         }
 
-        if (password_verify($token, $resetPasswordRequest->getHashedToken())) {
+        if (!password_verify($token, $resetPasswordRequest->getHashedToken())) {
             throw new InvalidArgumentException('Invalid reset password token.');
         }
 
         return $resetPasswordRequest;
     }
-
 }

--- a/src/Service/EmailServiceInterface.php
+++ b/src/Service/EmailServiceInterface.php
@@ -2,9 +2,12 @@
 
 namespace App\Service;
 
+use App\Entity\ResetPasswordRequest;
 use App\Entity\User;
 
 interface EmailServiceInterface
 {
     public function sendEmailVerification(User $user): void;
+
+    public function sendResetPasswordEmail(ResetPasswordRequest $resetPasswordRequest): void;
 }

--- a/src/Service/TokenGenerator.php
+++ b/src/Service/TokenGenerator.php
@@ -17,7 +17,7 @@ class TokenGenerator implements TokenGeneratorInterface
      */
     public function generateToken(int $length = 32): string
     {
-        return bin2hex(random_bytes($length / 2));
+        return bin2hex(random_bytes($length));
     }
 
     /**
@@ -34,4 +34,8 @@ class TokenGenerator implements TokenGeneratorInterface
         ];
     }
 
+    public function generateSelector(int $length = 16): string
+    {
+        return bin2hex(random_bytes($length));
+    }
 }

--- a/src/Service/TokenGeneratorInterface.php
+++ b/src/Service/TokenGeneratorInterface.php
@@ -16,4 +16,11 @@ interface TokenGeneratorInterface
      */
     public function generateExpiringToken(int $length = 32, int $ttlSeconds = 3600): array;
 
+
+    /**
+     * Generate a selector for password reset requests.
+     * @return string
+     */
+    public function generateSelector(int $length = 16): string;
+
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -249,18 +249,6 @@
             "webpack.config.js"
         ]
     },
-    "symfonycasts/reset-password-bundle": {
-        "version": "1.23",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "main",
-            "version": "1.0",
-            "ref": "97c1627c0384534997ae1047b93be517ca16de43"
-        },
-        "files": [
-            "config/packages/reset_password.yaml"
-        ]
-    },
     "symfonycasts/verify-email-bundle": {
         "version": "v1.17.3"
     },

--- a/templates/mail/reset_password_email.html.twig
+++ b/templates/mail/reset_password_email.html.twig
@@ -1,4 +1,4 @@
-{% extends "mail/base.html.twig"  %}
+{% extends "mail/base.html.twig" %}
 
 {% block content %}
 <h1>Password Reset Request</h1>

--- a/templates/mail/reset_password_email.html.twig
+++ b/templates/mail/reset_password_email.html.twig
@@ -1,11 +1,13 @@
-<h1>Hi!</h1>
+{% extends "mail/base.html.twig"  %}
 
-<p>We received a request to reset your SpeakUp account password.</p>
-<p>To reset your password, please visit the following link</p>
+{% block content %}
+<h1>Password Reset Request</h1>
+<p>Hello {{ name }},</p>
+<p>We received a request to reset your password. Click the link below to set a new password:</p>
+<p>
+    <a href="{{ resetUrl }}">Reset My Password</a><br><br>
+    This link will expire at {{ expiresAt }}.
+</p>
+{% endblock %}
 
-<a href="{{ url('app_reset_password', {token: resetToken.token}) }}">{{ url('app_reset_password', {token: resetToken.token}) }}</a>
-
-<p>This link will expire in {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.</p>
-
-<p>Cheers!</p>
 

--- a/tests/Handler/PasswordResetFinalHandlerTest.php
+++ b/tests/Handler/PasswordResetFinalHandlerTest.php
@@ -111,7 +111,7 @@ class PasswordResetFinalHandlerTest extends TestCase
     #[Group('handler')]
     public function testThrowsRuntimeExceptionOnFlushFailure(): void
     {
-       $dto = new ResetPassword(
+        $dto = new ResetPassword(
             selector: 'selector123',
             token: 'token123',
             password: 'NewPassword123!',

--- a/tests/Handler/PasswordResetFinalHandlerTest.php
+++ b/tests/Handler/PasswordResetFinalHandlerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Tests\Handler;
+
+use App\DTO\ResetPassword;
+use App\Entity\ResetPasswordRequest;
+use App\Entity\Student;
+use App\Handler\PasswordResetFinalHandler;
+use App\Handler\PasswordResetValidationHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class PasswordResetFinalHandlerTest extends TestCase
+{
+    /**
+     * Tests that a valid password reset request successfully resets the password and removes the request.
+     */
+    #[Group('handler')]
+    public function testPasswordIsResetAndResetRequestIsRemoved(): void
+    {
+        $dto = new ResetPassword(
+            selector: 'selector123',
+            token: 'token123',
+            password: 'NewPassword123!',
+            passwordConfirmation: 'NewPassword123!'
+        );
+
+        $user = (new Student())->setEmail('student@example.com');
+
+        $resetRequest = $this->getMockBuilder(ResetPasswordRequest::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getUser'])
+            ->getMock();
+
+        $resetRequest->method('getUser')->willReturn($user);
+
+        $validator = $this->createMock(PasswordResetValidationHandler::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->with($dto->selector, $dto->token)
+            ->willReturn($resetRequest);
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $hasher->expects($this->once())
+            ->method('hashPassword')
+            ->with($user, $dto->password)
+            ->willReturn('hashed-password');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $em->expects($this->once())
+            ->method('remove')
+            ->with($resetRequest);
+
+        $em->expects($this->once())
+            ->method('flush');
+
+        $handler = new PasswordResetFinalHandler(
+            em: $em,
+            validator: $validator,
+            hasher: $hasher
+        );
+
+        $handler->handle($dto);
+
+        $this->assertSame('hashed-password', $user->getPassword());
+    }
+
+    /**
+     * Tests that an invalid token during validation throws an InvalidArgumentException.
+     */
+    #[Group('handler')]
+    public function testInvalidTokenThrowsException(): void
+    {
+        $dto = new ResetPassword(
+            selector: 'selector123',
+            token: 'invalid-token',
+            password: 'NewPassword123!',
+            passwordConfirmation: 'NewPassword123!'
+        );
+
+        $validator = $this->createMock(PasswordResetValidationHandler::class);
+
+        $validator->expects($this->once())
+            ->method('validate')
+            ->with($dto->selector, $dto->token)
+            ->willThrowException(new InvalidArgumentException('Invalid reset password token.'));
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $handler = new PasswordResetFinalHandler(
+            em: $em,
+            validator: $validator,
+            hasher: $hasher
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid reset password token.');
+
+        $handler->handle($dto);
+    }
+
+    /**
+     * Tests that a failure during flush throws a RuntimeException.
+     */
+    #[Group('handler')]
+    public function testThrowsRuntimeExceptionOnFlushFailure(): void
+    {
+       $dto = new ResetPassword(
+            selector: 'selector123',
+            token: 'token123',
+            password: 'NewPassword123!',
+            passwordConfirmation: 'NewPassword123!'
+        );
+        $user = (new Student())->setEmail('student@example.com');
+
+        $resetRequest = $this->getMockBuilder(ResetPasswordRequest::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getUser'])
+            ->getMock();
+        $resetRequest->method('getUser')->willReturn($user);
+
+        $validator = $this->createMock(PasswordResetValidationHandler::class);
+        $validator->method('validate')->willReturn($resetRequest);
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('hashed-password');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('remove')->with($resetRequest);
+        $em->expects($this->once())
+            ->method('flush')
+            ->willThrowException(new \Exception('DB error'));
+
+        $handler = new PasswordResetFinalHandler(
+            em: $em,
+            validator: $validator,
+            hasher: $hasher
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to reset password: DB error');
+
+        $handler->handle($dto);
+    }
+
+
+
+
+}

--- a/tests/Handler/PasswordResetValidationHandlerTest.php
+++ b/tests/Handler/PasswordResetValidationHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\Handler;
+
+use App\Entity\ResetPasswordRequest;
+use App\Entity\Student;
+use App\Handler\PasswordResetValidationHandler;
+use App\Repository\ResetPasswordRequestRepository;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+class PasswordResetValidationHandlerTest extends TestCase
+{
+    private ResetPasswordRequestRepository $repo;
+    private PasswordResetValidationHandler $validator;
+
+    protected function setUp(): void
+    {
+        $this->repo = $this->createMock(ResetPasswordRequestRepository::class);
+        $this->validator = new PasswordResetValidationHandler($this->repo);
+    }
+
+    /*
+     * Tests that a valid token passes validation and returns the correct request.
+     */
+    #[Group('handler')]
+    public function testValidTokenPassesValidation(): void
+    {
+        $selector = 'selector-123';
+        $plainToken = 'good-token';
+        $hashed = password_hash($plainToken, PASSWORD_ARGON2ID);
+
+        $user = (new Student())->setEmail('student@example.com');
+
+        $request = new ResetPasswordRequest(
+            user: $user,
+            hashedToken: $hashed,
+            selector: $selector,
+            expiresAt: new \DateTimeImmutable('+1 hour')
+        );
+
+        $this->repo->expects($this->once())
+            ->method('findOneBySelector')
+            ->with($selector)
+            ->willReturn($request);
+
+        $result = $this->validator->validate($selector, $plainToken);
+
+        $this->assertSame($request, $result);
+    }
+
+    /*
+     * Tests that an invalid selector throws an InvalidArgumentException.
+     */
+    #[Group('handler')]
+    public function testInvalidSelectorThrowsException(): void
+    {
+        $this->repo->method('findOneBySelector')->willReturn(null);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->validator->validate('missing', 'token');
+    }
+
+    /*
+     * Tests that an expired token throws an InvalidArgumentException.
+     */
+    #[Group('handler')]
+    public function testExpiredTokenThrowsException(): void
+    {
+        $selector = 'selector-123';
+        $token = 'expired-token';
+        $hashed = password_hash($token, PASSWORD_ARGON2ID);
+
+        $user = new Student();
+
+        $request = new ResetPasswordRequest(
+            user: $user,
+            hashedToken: $hashed,
+            selector: $selector,
+            expiresAt: new \DateTimeImmutable('-1 hour')
+        );
+
+        $this->repo->method('findOneBySelector')->willReturn($request);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validate($selector, $token);
+    }
+
+    /*
+     * Tests that a wrong token throws an InvalidArgumentException.
+     */
+    #[Group('handler')]
+    public function testWrongTokenThrowsException(): void
+    {
+        $selector = 'selector-123';
+        $correct = 'secret';
+        $wrong = 'bad-token';
+
+        $hashed = password_hash($correct, PASSWORD_ARGON2ID);
+
+        $user = new Student();
+
+        $request = new ResetPasswordRequest(
+            user: $user,
+            hashedToken: $hashed,
+            selector: $selector,
+            expiresAt: new \DateTimeImmutable('+1 hour')
+        );
+
+        $this->repo->method('findOneBySelector')->willReturn($request);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validate($selector, $wrong);
+    }
+}

--- a/tests/Handler/PasswordResetValidationHandlerTest.php
+++ b/tests/Handler/PasswordResetValidationHandlerTest.php
@@ -21,7 +21,7 @@ class PasswordResetValidationHandlerTest extends TestCase
         $this->validator = new PasswordResetValidationHandler($this->repo);
     }
 
-    /*
+    /**
      * Tests that a valid token passes validation and returns the correct request.
      */
     #[Group('handler')]
@@ -50,7 +50,7 @@ class PasswordResetValidationHandlerTest extends TestCase
         $this->assertSame($request, $result);
     }
 
-    /*
+    /**
      * Tests that an invalid selector throws an InvalidArgumentException.
      */
     #[Group('handler')]
@@ -63,7 +63,7 @@ class PasswordResetValidationHandlerTest extends TestCase
         $this->validator->validate('missing', 'token');
     }
 
-    /*
+    /**
      * Tests that an expired token throws an InvalidArgumentException.
      */
     #[Group('handler')]
@@ -88,7 +88,7 @@ class PasswordResetValidationHandlerTest extends TestCase
         $this->validator->validate($selector, $token);
     }
 
-    /*
+    /**
      * Tests that a wrong token throws an InvalidArgumentException.
      */
     #[Group('handler')]


### PR DESCRIPTION
**Summary**  
This PR introduces a complete backend implementation of the password reset flow. It includes requesting a reset link, generating secure selector/token pairs, validating the reset token, and applying the final password update. The frontend for this flow will be added in a separate pull request.

**Key changes**  
1. Added `PasswordResetRequestHandler` responsible for generating selector/token, hashing the token, saving the reset request, and dispatching `ResetPasswordRequestedEvent` to `SendResetPasswordListener`.  
2. Extended `EmailService` with `sendResetPasswordEmail` and added a dedicated email template for password resets.  
3. Added `PasswordResetValidationHandler` to validate the selector, token, and expiration timestamp.  
4. Added `PasswordResetFinalHandler` for re-validating the token, hashing the new password, updating the user, and removing the reset request.  
6. Added `ResetPassword` DTO with Symfony validation rules for password and confirmation.  
7. Added controller endpoints for requesting a reset, validating a token, and submitting the final new password.  
8. Added unit tests covering success cases, invalid tokens, and database failure scenarios.

**Testing**  
New PHPUnit tests were added for PasswordResetRequestHandler and PasswordResetFinalHandler, covering both positive and negative scenarios. All tests pass successfully.
